### PR TITLE
Added array return type to _getSidebarNavigation()

### DIFF
--- a/src/Listener/Traits/SidebarNavigationTrait.php
+++ b/src/Listener/Traits/SidebarNavigationTrait.php
@@ -24,9 +24,9 @@ trait SidebarNavigationTrait
     /**
      * Returns the sidebar navigation to show on scaffolded view
      *
-     * @return string|false|null
+     * @return array|string|false|null
      */
-    protected function _getSidebarNavigation(): string|false|null
+    protected function _getSidebarNavigation(): array|string|false|null
     {
         $action = $this->_action();
 


### PR DESCRIPTION
The sidebar navigation allows custom item configuration using an array https://crud-view.readthedocs.io/en/latest/general-configuration/sidebar-navigation.html 

Added array return type to _getSidebarNavigation to prevent type exception.